### PR TITLE
Make sure the optimizer does not remove the code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,45 +10,51 @@ use test::Bencher;
 #[bench]
 fn format_macro(b: &mut Bencher) {
     b.iter(||{
-        let _datetime = format!("{}T{}", DATE, TIME);
+        let datetime = format!("{}T{}", DATE, TIME);
+        test::black_box(datetime);
     });
 }
 
 #[bench]
 fn to_string_plus_op(b: &mut Bencher) {
     b.iter(||{
-        let _datetime = &(DATE.to_string() + "T" + TIME);
+        let datetime = &(DATE.to_string() + "T" + TIME);
+        test::black_box(datetime);
     });
 }
 
 #[bench]
 fn to_owned_plus_op(b: &mut Bencher) {
     b.iter(||{
-        let _datetime = &(DATE.to_owned() + "T" + TIME);
+        let datetime = &(DATE.to_owned() + "T" + TIME);
+        test::black_box(datetime);
     });
 }
 
 #[bench]
 fn string_from_plus_op(b: &mut Bencher) {
     b.iter(||{
-        let _datetime = &(String::from(DATE) + "T" + TIME);
+        let datetime = &(String::from(DATE) + "T" + TIME);
+        test::black_box(datetime);
     });
 }
 
 #[bench]
 fn mut_string_push_str(b: &mut Bencher) {
     b.iter(||{
-        let mut _datetime = String::new();
-        _datetime.push_str(DATE);
-        _datetime.push_str("T");
-        _datetime.push_str(TIME);
+        let mut datetime = String::new();
+        datetime.push_str(DATE);
+        datetime.push_str("T");
+        datetime.push_str(TIME);
+        test::black_box(datetime);
     });
 }
 
 #[bench]
 fn array_concat(b: &mut Bencher) {
     b.iter(||{
-        let mut _datetime = [ DATE, "T", TIME ].concat();
+        let mut datetime = [ DATE, "T", TIME ].concat();
+        test::black_box(datetime);
     });
 }
 
@@ -56,5 +62,6 @@ fn array_concat(b: &mut Bencher) {
 fn array_join(b: &mut Bencher) {
     b.iter(||{
         let mut datetime = [ "2014-11-28", "12:00:09Z" ].join("T");
+        test::black_box(datetime);
     });
 }


### PR DESCRIPTION
My results:

```
running 7 tests
test array_concat        ... bench:          46 ns/iter (+/- 1)
test array_join          ... bench:          19 ns/iter (+/- 0)
test format_macro        ... bench:          99 ns/iter (+/- 7)
test mut_string_push_str ... bench:          44 ns/iter (+/- 1)
test string_from_plus_op ... bench:          43 ns/iter (+/- 1)
test to_owned_plus_op    ... bench:          50 ns/iter (+/- 38)
test to_string_plus_op   ... bench:          72 ns/iter (+/- 3)

test result: ok. 0 passed; 0 failed; 0 ignored; 7 measured
```