### PR TITLE
Remove duplicated benchmark

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -153,14 +153,6 @@ fn array_join(b: &mut Bencher) {
 }
 
 #[bench]
-fn array_join_long(b: &mut Bencher) {
-    b.iter(|| {
-               let datetime: &str = &[DATE, "T", TIME].join("");
-               test::black_box(datetime);
-           });
-}
-
-#[bench]
 fn array_join_empty_arg(b: &mut Bencher) {
     b.iter(|| {
                let datetime: &str = &[DATE, "T", TIME].join("");


### PR DESCRIPTION
Apart from name `array_join_long` is exactly the same as `array_join_empty_arg`.

Some fresh results:
```
running 17 tests
test array_concat                                 ... bench:          28 ns/iter (+/- 1)
test array_join                                   ... bench:          36 ns/iter (+/- 2)
test array_join_empty_arg                         ... bench:          29 ns/iter (+/- 2)
test collect_to_string                            ... bench:          77 ns/iter (+/- 4)
test format_macro                                 ... bench:         103 ns/iter (+/- 4)
test from_bytes                                   ... bench:           1 ns/iter (+/- 0)
test mut_string_push_str                          ... bench:          75 ns/iter (+/- 3)
test mut_string_push_string                       ... bench:         149 ns/iter (+/- 5)
test mut_string_with_capacity_push_str            ... bench:          25 ns/iter (+/- 2)
test mut_string_with_capacity_push_str_char       ... bench:          24 ns/iter (+/- 1)
test mut_string_with_too_little_capacity_push_str ... bench:         114 ns/iter (+/- 5)
test mut_string_with_too_much_capacity_push_str   ... bench:          26 ns/iter (+/- 2)
test string_from_all                              ... bench:         150 ns/iter (+/- 14)
test string_from_plus_op                          ... bench:          65 ns/iter (+/- 5)
test to_owned_plus_op                             ... bench:          70 ns/iter (+/- 4)
test to_string_plus_op                            ... bench:          65 ns/iter (+/- 4)
test write_macro                                  ... bench:         112 ns/iter (+/- 7)

test result: ok. 0 passed; 0 failed; 0 ignored; 17 measured; 0 filtered out
```