### PR TITLE
Fix typo in `collect_from_vec_to_string` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ let list = [DATE, T, TIME];
 let datetime: String = list.iter().map(|x| *x).collect();
 ```
 
-### `collect_from_vecto_string()`
+### `collect_from_vec_to_string()`
 ```rust
 let list = vec![DATE, T, TIME];
 let datetime: String = list.iter().map(|x| *x).collect();


### PR DESCRIPTION
I attempted to Ctrl+F (search in page) to get the time for this example, but it only matched the header due to the typo.