### PR TITLE
Take warning for `from_bytes()` out of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ let datetime: String = list.iter().map(|x| *x).collect();
 let datetime = &format!("{}{}{}", DATE, T, TIME);
 ```
 
-### `from_bytes() // ⚠️ don't actually do this`
+### `from_bytes()` ⚠️ don't actually do this
 
 ```rust
 use std::ffi::OsStr;


### PR DESCRIPTION
Move the warning for `from_bytes()` out of the comment because it looks
a bit bulky, and on some (if not all) OS's, the warning emoji doesn't
appear in full color when it's in code.